### PR TITLE
Always keep connection alive unless Connection: close is sent

### DIFF
--- a/src/party_socket.erl
+++ b/src/party_socket.erl
@@ -117,7 +117,8 @@ handle_info({tcp, Socket, Data}, #state{socket = Socket} = State) ->
                             {<<"Connection">>, <<"close">>} ->
                                 ok = gen_tcp:close(Socket),
                                 undefined;
-                            {<<"Connection">>, <<"keep-alive">>} ->
+                            {<<"Connection">>, _} ->
+                                %% Keep alive is default for HTTP 1.1
                                 Socket;
                             false ->
                                 Socket

--- a/test/party_test.erl
+++ b/test/party_test.erl
@@ -68,7 +68,7 @@ reconnect() ->
 
     {ok, Socket1} = party_socket:get_socket(Pid),
 
-    KeepAlive = [{<<"Connection">>, <<"keep-alive">>}],
+    KeepAlive = [],
     ?assertMatch({ok, {{400, _}, _, _}}, party:post(URL, KeepAlive, [], [])),
     ?assertEqual({ok, Socket1}, party_socket:get_socket(Pid)),
 


### PR DESCRIPTION
Some webservers sends Connection: Keep-Alive, since its the default in the spec anyway we don't need to match any specific case/value as long as its not Connection: close
