### PR TITLE
Depend on carpool

### DIFF
--- a/src/party.app.src
+++ b/src/party.app.src
@@ -5,7 +5,8 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib
+                  stdlib,
+                  carpool
                  ]},
   {mod, { party_app, []}},
   {env, []}

--- a/src/party_app.erl
+++ b/src/party_app.erl
@@ -10,7 +10,6 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
-    application:start(carpool),
     party_sup:start_link().
 
 stop(_State) ->


### PR DESCRIPTION
Adds proper dependency to carpool and removes "un-OTP-ish" application start call.
